### PR TITLE
Add a cw on/off CLI command for output and antenna measurement

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -5061,22 +5061,15 @@ bool MyMesh::setTxPower(int8_t power_dbm) {
 }
 
 bool MyMesh::setCarrierWave(bool on) {
-#if defined(ESP32_PLATFORM)
-  // Light sleep powers down the RTC peripheral domain, and that is where the
-  // ESP32's DACs live. On a board whose amplifier gain is a DAC voltage, the
-  // output collapses at the first sleep with nothing in the logs to say so.
-  // Stay awake for the duration of the carrier.
-  if (on) board.setInhibitSleep(true);
-#endif
-  const bool ok = radio_driver.setCarrierWave(on);
-#if defined(ESP32_PLATFORM)
-  if (!on || !ok) board.setInhibitSleep(false);
-#endif
-  return ok;
+  return radio_driver.setCarrierWave(on);
 }
 
 bool MyMesh::isCarrierWaveActive() const {
   return radio_driver.isCarrierWaveActive();
+}
+
+uint32_t MyMesh::carrierWaveHoldSecs() const {
+  return radio_driver.carrierWaveHoldSecs();
 }
 
 bool MyMesh::setRxPowerSaving(bool enable, uint32_t rx_us, uint32_t sleep_us) {

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -5060,6 +5060,25 @@ bool MyMesh::setTxPower(int8_t power_dbm) {
   return radio_driver.setTxPower(power_dbm);
 }
 
+bool MyMesh::setCarrierWave(bool on) {
+#if defined(ESP32_PLATFORM)
+  // Light sleep powers down the RTC peripheral domain, and that is where the
+  // ESP32's DACs live. On a board whose amplifier gain is a DAC voltage, the
+  // output collapses at the first sleep with nothing in the logs to say so.
+  // Stay awake for the duration of the carrier.
+  if (on) board.setInhibitSleep(true);
+#endif
+  const bool ok = radio_driver.setCarrierWave(on);
+#if defined(ESP32_PLATFORM)
+  if (!on || !ok) board.setInhibitSleep(false);
+#endif
+  return ok;
+}
+
+bool MyMesh::isCarrierWaveActive() const {
+  return radio_driver.isCarrierWaveActive();
+}
+
 bool MyMesh::setRxPowerSaving(bool enable, uint32_t rx_us, uint32_t sleep_us) {
   bool ok = radio_driver.setRxPowerSaving(enable, rx_us, sleep_us);
   MESH_DEBUG_PRINTLN("RX Power Saving: %s (%lu/%lu us)%s",

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -1017,6 +1017,8 @@ public:
   void cancelPendingSerialOutput();
 #endif
   bool setTxPower(int8_t power_dbm) override;
+  bool setCarrierWave(bool on) override;
+  bool isCarrierWaveActive() const override;
   bool setRxPowerSaving(bool enable, uint32_t rx_us, uint32_t sleep_us) override;
   bool supportsRxPowerSavingRfRxDisable() const override;
   bool setRxPowerSavingRfRxDisabled(bool disabled) override;

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -1019,6 +1019,7 @@ public:
   bool setTxPower(int8_t power_dbm) override;
   bool setCarrierWave(bool on) override;
   bool isCarrierWaveActive() const override;
+  uint32_t carrierWaveHoldSecs() const override;
   bool setRxPowerSaving(bool enable, uint32_t rx_us, uint32_t sleep_us) override;
   bool supportsRxPowerSavingRfRxDisable() const override;
   bool setRxPowerSavingRfRxDisabled(bool disabled) override;

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -308,6 +308,14 @@ void Dispatcher::loop() {
   }
   _radio->loop();
 
+  // A held carrier parks the radio outside RX with the PA keyed on purpose, so
+  // the node is off the mesh until it drops. Everything below is hostile to
+  // that: the stuck-outside-RX check resets the chip after 8 s and tears the
+  // carrier down mid-measurement, and the outbound pump would transmit packets
+  // straight into it. Radio::loop() above is what expires the carrier, so it
+  // has to run first.
+  if (_radio->isCarrierWaveActive()) return;
+
   const unsigned long now = _ms->getMillis();
   const unsigned long latest_irq = _radio->getLastRadioInterruptMillis();
   if (latest_irq != 0 && latest_irq != last_observed_radio_irq) {

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -120,6 +120,11 @@ public:
 
   virtual bool isInRecvMode() const = 0;
 
+  // True while an unmodulated carrier is deliberately held. The radio sits
+  // outside RX with the PA keyed, which the watchdogs would otherwise read as
+  // a stuck radio.
+  virtual bool isCarrierWaveActive() const { return false; }
+
   virtual bool supportsRxPowerSaving() const { return false; }
   virtual bool setRxPowerSaving(bool enabled, uint32_t rx_us, uint32_t sleep_us) { return !enabled; }
   virtual bool isRxPowerSavingContinuousFallback() const { return false; }

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -151,6 +151,9 @@ public:
   // Default no-op: boards that don't care need not implement anything.
   virtual void onBootComplete() { /* no op */ }
   virtual uint32_t getIRQGpio() { return -1; } // not supported. Returns DIO1 (SX1262) and DIO0 (SX127x)
+  // Hold off sleep while something needs the MCU awake. Boards that do not
+  // sleep can ignore it.
+  virtual void setInhibitSleep(bool /*inhibit*/) { /* no op */ }
   virtual void sleep(uint32_t secs)  {
     (void)secs;
 #if defined(RP2040_PLATFORM) || defined(STM32_PLATFORM)

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -2477,6 +2477,25 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       // send zerohop advert
       _callbacks->sendSelfAdvertisement(1500, false);  // longer delay, give CLI response time to be sent first
       strcpy(reply, "OK - zerohop advert sent");
+    } else if (memcmp(command, "cw", 2) == 0 && (command[2] == 0 || command[2] == ' ')) {
+      // Unmodulated carrier at the current TX power, for measuring output or
+      // checking an antenna. This keys the PA continuously - a duty cycle most
+      // amplifiers here were never specified for - so keep it brief.
+      const char* arg = &command[2];
+      while (*arg == ' ') arg++;
+      if (memcmp(arg, "on", 2) == 0) {
+        if (_callbacks->setCarrierWave(true)) {
+          strcpy(reply, "OK - carrier ON, node is off the mesh until 'cw off'");
+        } else {
+          strcpy(reply, "Err - carrier wave not supported by this radio");
+        }
+      } else if (memcmp(arg, "off", 3) == 0) {
+        strcpy(reply, _callbacks->setCarrierWave(false)
+                        ? "OK - carrier off, receive resumed"
+                        : "Err - failed to restore receive; reboot advised");
+      } else {
+        sprintf(reply, "> %s", _callbacks->isCarrierWaveActive() ? "on" : "off");
+      }
     } else if (memcmp(command, "advert", 6) == 0) {
       // send flood advert
       _callbacks->sendSelfAdvertisement(1500, true);  // longer delay, give CLI response time to be sent first

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -2485,7 +2485,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       while (*arg == ' ') arg++;
       if (memcmp(arg, "on", 2) == 0) {
         if (_callbacks->setCarrierWave(true)) {
-          strcpy(reply, "OK - carrier ON, node is off the mesh until 'cw off'");
+          sprintf(reply, "OK - carrier ON, node off the mesh, drops after %us unless repeated",
+                  (unsigned)_callbacks->carrierWaveHoldSecs());
         } else {
           strcpy(reply, "Err - carrier wave not supported by this radio");
         }

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -478,6 +478,7 @@ public:
   // for everything else while active; not every radio can do it.
   virtual bool setCarrierWave(bool /*on*/) { return false; }
   virtual bool isCarrierWaveActive() const { return false; }
+  virtual uint32_t carrierWaveHoldSecs() const { return 0; }
   virtual void formatNeighborsReply(char *reply) = 0;
   virtual void removeNeighbor(const uint8_t* pubkey, int key_len) {
     // no op by default

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -474,6 +474,10 @@ public:
   virtual void eraseLogFile() = 0;
   virtual void dumpLogFile() = 0;
   virtual bool setTxPower(int8_t power_dbm) = 0;
+  // Hold an unmodulated carrier for output/antenna measurement. Off the air
+  // for everything else while active; not every radio can do it.
+  virtual bool setCarrierWave(bool /*on*/) { return false; }
+  virtual bool isCarrierWaveActive() const { return false; }
   virtual void formatNeighborsReply(char *reply) = 0;
   virtual void removeNeighbor(const uint8_t* pubkey, int key_len) {
     // no op by default

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -253,7 +253,7 @@ public:
 #endif
   }
 
-  void setInhibitSleep(bool inhibit) {
+  void setInhibitSleep(bool inhibit) override {
     inhibit_sleep = inhibit;
   }
 

--- a/src/helpers/radiolib/CustomSX1276Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1276Wrapper.h
@@ -44,6 +44,30 @@ protected:
     return ((CustomSX1276 *)_radio)->tryScanChannel(cadScanTimeoutMillis(), *_board);
   }
 
+  // Power handed to the FSK modem while keying a carrier. A board whose radio
+  // only drives an external amplifier overrides this: giving beginFSK() the
+  // user-facing dBm would push the PA far past the input it expects.
+  virtual int8_t carrierDriveDbm() const { return LORA_TX_POWER; }
+
+  // SX127x cannot emit a carrier from the LoRa modem - RadioLib's
+  // transmitDirect() returns RADIOLIB_ERR_WRONG_MODEM there. So CW means
+  // switching to FSK, and leaving it means rebuilding the LoRa config.
+  int16_t enterCarrierWave() override {
+    CustomSX1276* radio = (CustomSX1276 *)_radio;
+    const float freq = _params_valid ? _cur_freq : (float)LORA_FREQ;
+    const int16_t status = radio->beginFSK(freq, 4.8, 5.0, 125.0,
+                                           carrierDriveDbm(), 16, false);
+    if (status != RADIOLIB_ERR_NONE) return status;
+    return radio->transmitDirect();
+  }
+
+  int16_t exitCarrierWave() override {
+    _radio->standby();
+    // restoreAfterDeepInit() performs the deep init itself; calling it here as
+    // well was a second, redundant hard reset.
+    return restoreAfterDeepInit() ? RADIOLIB_ERR_NONE : RADIOLIB_ERR_UNKNOWN;
+  }
+
   bool radioDeepInit() override {
     if (!prepareRadioHardReset()) return false;
     return ((CustomSX1276 *)_radio)->std_init() && _board->finishRadioHardReset();

--- a/src/helpers/radiolib/CustomSX1276Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1276Wrapper.h
@@ -52,10 +52,18 @@ protected:
   // SX127x cannot emit a carrier from the LoRa modem - RadioLib's
   // transmitDirect() returns RADIOLIB_ERR_WRONG_MODEM there. So CW means
   // switching to FSK, and leaving it means rebuilding the LoRa config.
+  //
+  // The frequency deviation must be zero. transmitDirect() with no argument
+  // calls directMode(), which maps DIO2 to the modulator's DATA input and puts
+  // the chip in continuous mode, so the transmitted frequency follows whatever
+  // level sits on that pin. Most boards do not wire DIO2 anywhere, which leaves
+  // it floating and picking up noise: with the stock 5 kHz deviation the result
+  // is not a carrier at all but a tone hopping randomly across a 10 kHz span.
+  // At zero deviation the data input cannot move the carrier, wired or not.
   int16_t enterCarrierWave() override {
     CustomSX1276* radio = (CustomSX1276 *)_radio;
     const float freq = _params_valid ? _cur_freq : (float)LORA_FREQ;
-    const int16_t status = radio->beginFSK(freq, 4.8, 5.0, 125.0,
+    const int16_t status = radio->beginFSK(freq, 4.8, 0.0, 125.0,
                                            carrierDriveDbm(), 16, false);
     if (status != RADIOLIB_ERR_NONE) return status;
     return radio->transmitDirect();

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -87,6 +87,22 @@ uint32_t RadioLibWrapper::getRngSeed() {
 }
 
 bool RadioLibWrapper::setTxPower(int8_t dbm) {
+  if (_cw_active) {
+    // Keyed for diagnostics. beginReconfigure() would refuse: the radio is not
+    // in RX, and on SX127x isReceivingPacket() reads LoRa modem-status
+    // registers that mean nothing once the FSK modem is driving the carrier.
+    // Sweeping power against a meter is the whole point of CW, so apply it.
+    const int16_t cw_status = applyCachedTxPower(dbm);
+    if (cw_status == RADIOLIB_ERR_NONE) {
+      _cur_dbm = dbm;
+      _dbm_valid = true;
+      return true;
+    }
+    MESH_DEBUG_PRINTLN("RadioLibWrapper: TX power %d rejected in CW (%d)",
+                       (int)dbm, (int)cw_status);
+    return false;
+  }
+
   const uint8_t resume_rx = beginReconfigure();
   if (resume_rx > 1) return false;
 
@@ -211,7 +227,32 @@ bool RadioLibWrapper::setRxBoostedGainMode(bool enabled) {
   return success;
 }
 
+bool RadioLibWrapper::setCarrierWave(bool on) {
+  if (on == _cw_active) return true;
+
+  if (on) {
+    _radio->standby();
+    _rx_hold_continuous = false;
+    _rx_ps_armed = false;
+    const int16_t status = enterCarrierWave();
+    if (status != RADIOLIB_ERR_NONE) {
+      MESH_DEBUG_PRINTLN("RadioLibWrapper: carrier wave refused (%d)", (int)status);
+      startRecv();              // _cw_active still false, so this re-arms
+      return false;
+    }
+    _cw_active = true;
+    state = STATE_IDLE;         // nothing is being received while keyed
+    return true;
+  }
+
+  _cw_active = false;           // cleared first so the guards below release
+  const int16_t status = exitCarrierWave();
+  startRecv();
+  return status == RADIOLIB_ERR_NONE;
+}
+
 void RadioLibWrapper::idle() {
+  if (_cw_active) return;   // held in carrier wave for diagnostics
   _radio->standby();
   _rx_hold_continuous = false;
   state = STATE_IDLE;   // need another startReceive()
@@ -539,6 +580,7 @@ void RadioLibWrapper::loop() {
 }
 
 void RadioLibWrapper::startRecv() {
+  if (_cw_active) return;   // held in carrier wave for diagnostics
   int err = startReceiveMode();
   if (err == RADIOLIB_ERR_NONE) {
     state = STATE_RX;

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -228,24 +228,35 @@ bool RadioLibWrapper::setRxBoostedGainMode(bool enabled) {
 }
 
 bool RadioLibWrapper::setCarrierWave(bool on) {
+  if (on && _cw_active) {
+    _cw_deadline = millis() + CW_HOLD_TIMEOUT_MS;   // asked again, keep going
+    return true;
+  }
   if (on == _cw_active) return true;
 
   if (on) {
+    // Light sleep powers down the RTC peripheral domain, and that is where the
+    // ESP32's DACs live. On a board whose amplifier gain is a DAC voltage the
+    // carrier would collapse at the first sleep with nothing in the logs.
+    _board->setInhibitSleep(true);
     _radio->standby();
     _rx_hold_continuous = false;
     _rx_ps_armed = false;
     const int16_t status = enterCarrierWave();
     if (status != RADIOLIB_ERR_NONE) {
       MESH_DEBUG_PRINTLN("RadioLibWrapper: carrier wave refused (%d)", (int)status);
+      _board->setInhibitSleep(false);
       startRecv();              // _cw_active still false, so this re-arms
       return false;
     }
     _cw_active = true;
+    _cw_deadline = millis() + CW_HOLD_TIMEOUT_MS;
     state = STATE_IDLE;         // nothing is being received while keyed
     return true;
   }
 
   _cw_active = false;           // cleared first so the guards below release
+  _board->setInhibitSleep(false);
   const int16_t status = exitCarrierWave();
   startRecv();
   return status == RADIOLIB_ERR_NONE;
@@ -489,6 +500,13 @@ void RadioLibWrapper::endNoiseFloorCalib(unsigned long now) {
 }
 
 void RadioLibWrapper::loop() {
+  if (_cw_active) {
+    if ((long)(millis() - _cw_deadline) >= 0) {
+      MESH_DEBUG_PRINTLN("RadioLibWrapper: carrier wave timed out, dropping");
+      setCarrierWave(false);
+    }
+    return;                     // nothing else here applies while keyed
+  }
   if (_rx_ps_enabled && !_rx_ps_continuous_fallback) {
     rxPsWatchdogCheck();
   }

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -44,6 +44,7 @@ protected:
   bool _rx_ps_armed;      // radio is currently in RX duty-cycle mode
   bool _rx_ps_continuous_fallback; // requested RXPS is receiving continuously for this tuple
   bool _rx_hold_continuous; // keep plain RX active until Dispatcher consumes cached metadata
+  bool _cw_active = false;  // unmodulated carrier held for diagnostics
   uint32_t _rx_ps_rx_us;
   uint32_t _rx_ps_sleep_us;
 
@@ -135,6 +136,13 @@ protected:
     return _radio->setOutputPower(dbm);
   }
   virtual bool applyRxBoostedGainMode(bool) { return false; }
+
+  // Carrier-wave hooks. The default suits a radio whose transmitDirect() can
+  // key a carrier from the mode the mesh already runs in - the LR11x0 family
+  // issues SetTxCw from here and sets its own RF switch. A radio that needs a
+  // different modem for CW overrides both and restores on the way out.
+  virtual int16_t enterCarrierWave() { return _radio->transmitDirect(); }
+  virtual int16_t exitCarrierWave() { return _radio->standby(); }
   // 0 = reconfigure from idle, 1 = resume RX afterwards, 2 = currently busy.
   uint8_t beginReconfigure();
   void endReconfigure(bool resume_rx);
@@ -194,6 +202,16 @@ public:
                  const uint32_t* rx_ps_timings = NULL);
   uint32_t getRngSeed();
   bool setTxPower(int8_t dbm);
+
+  // Hold an unmodulated carrier at the current TX power, for measuring output
+  // or checking an antenna. While it is active the mesh cannot re-arm receive,
+  // so the node is off the air for everything else until it is turned off.
+  //
+  // This keys the PA continuously, which is a duty cycle most amplifiers on
+  // this class of hardware were never specified for. Keep it brief at high
+  // power.
+  bool setCarrierWave(bool on);
+  bool isCarrierWaveActive() const { return _cw_active; }
 
   virtual float getCurrentRSSI() =0;
   virtual uint8_t getSpreadingFactor() const { return LORA_SF; }

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -220,7 +220,7 @@ public:
   // this class of hardware were never specified for. Keep it brief at high
   // power.
   bool setCarrierWave(bool on);
-  bool isCarrierWaveActive() const { return _cw_active; }
+  bool isCarrierWaveActive() const override { return _cw_active; }
   // How long a carrier holds before it drops itself, for the CLI to quote.
   uint32_t carrierWaveHoldSecs() const { return CW_HOLD_TIMEOUT_MS / 1000; }
 

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -13,6 +13,14 @@
 #define RX_PS_FALLBACK_RX_US    65625UL
 #define RX_PS_FALLBACK_SLEEP_US 60000UL
 
+// A held carrier keys the PA continuously, which is a duty cycle most
+// amplifiers on this class of hardware were never specified for. It drops
+// itself unless something asks again, so a forgotten 'cw on' cannot sit
+// there cooking a board.
+#ifndef CW_HOLD_TIMEOUT_MS
+#define CW_HOLD_TIMEOUT_MS 10000UL
+#endif
+
 #ifdef USE_CC310_HW_CRYPTO
 #include "../NRF52Crypto.h"
 #endif
@@ -45,6 +53,7 @@ protected:
   bool _rx_ps_continuous_fallback; // requested RXPS is receiving continuously for this tuple
   bool _rx_hold_continuous; // keep plain RX active until Dispatcher consumes cached metadata
   bool _cw_active = false;  // unmodulated carrier held for diagnostics
+  unsigned long _cw_deadline = 0;  // millis() at which it drops itself
   uint32_t _rx_ps_rx_us;
   uint32_t _rx_ps_sleep_us;
 
@@ -212,6 +221,8 @@ public:
   // power.
   bool setCarrierWave(bool on);
   bool isCarrierWaveActive() const { return _cw_active; }
+  // How long a carrier holds before it drops itself, for the CLI to quote.
+  uint32_t carrierWaveHoldSecs() const { return CW_HOLD_TIMEOUT_MS / 1000; }
 
   virtual float getCurrentRSSI() =0;
   virtual uint8_t getSpreadingFactor() const { return LORA_SF; }


### PR DESCRIPTION
Adds `cw on` / `cw off` to hold an unmodulated carrier at the current TX power, for putting a node on a meter or checking an antenna. The carrier drops itself 10 seconds after the last `cw on` so a forgotten one can't sit there cooking a PA, and repeating the command extends it instead of re-keying.

Two things worth a reviewer's eye. `transmitDirect()` on SX127x maps DIO2 to the FSK modulator's data input, so it needs zero deviation, otherwise an unconnected DIO2 floats and smears the carrier across 10 kHz. And `Dispatcher` treats a keyed radio as a stuck one and resets it after 8s, inside the hold, so the watchdogs and the outbound pump now skip while `isCarrierWaveActive()` (defaults false, so nothing else changes).

Tested on an SX1276 with an external PA, 17 to 33dBm swept into an ImmersionRC meter, tracked the board's power table within 1.5dB.